### PR TITLE
Fix KillProof.me link in ping chat message

### DIFF
--- a/KillProofModule.cs
+++ b/KillProofModule.cs
@@ -1450,7 +1450,7 @@ namespace KillProofModule
                     }
 
                     chatLink.Quantity = Convert.ToByte(1);
-                    GameIntegration.Chat.Send($"Total: {_myKillProof.GetToken(singleRandomToken.Id)?.Amount ?? 0} of {chatLink} (killproof.me/{_myKillProof.KpId})");
+                    GameIntegration.Chat.Send($"Total: {_myKillProof.GetToken(singleRandomToken.Id)?.Amount ?? 0} of {chatLink} (killproof.me/proof/{_myKillProof.KpId})");
 
                 } else {
 


### PR DESCRIPTION
The KillProof.me module sends a link to the chat that results in a 404
e.g. `https://killproof.me/<killproofID>`
should be: `https://killproof.me/proof/<killproofID>`